### PR TITLE
[Feature] - Persist event type filter in url param and allow end users to solo event type filter in one click

### DIFF
--- a/sms_frontend/src/components/FilterPanel/FilterPanelContent.tsx
+++ b/sms_frontend/src/components/FilterPanel/FilterPanelContent.tsx
@@ -31,7 +31,6 @@ export const FilterPanelContent = () => {
   } = useContext(LocalStorageContext) || {};
   const [filterPanelDate, setFilterPanelDate] = useState(selectedDate);
   const [searchParams, setSearchParams] = useSearchParams();
-  const eventTypeStrings = useMemo(() => ['Open Mic', 'Show', 'Open Jam'], [])
 
   const EVENT_TYPES_KEY = 'eventTypes'
 
@@ -48,19 +47,22 @@ useEffect(() => {
   } else {
     setSelectedEventTypes?.([]);
   }
-}, [eventTypeStrings, getEventTypesFromURL, setSelectedEventTypes]); // Only re-run the effect if the URL changes
+}, [getEventTypesFromURL, setSelectedEventTypes]); // Only re-run the effect if the URL changes
 
   useEffect(() => {
     setFilterPanelDate(selectedDate);
   }, [selectedDate]);
 
   useEffect(() => {
-    if (selectedEventTypes?.length && !eventTypeStrings.every(type => selectedEventTypes.includes(type))) {
+    if(!eventTypes.length){
+      return
+    } 
+    if (selectedEventTypes?.length && !eventTypes.every(type => selectedEventTypes.includes(type))) {
       setSearchParams({ eventTypes: selectedEventTypes.join(',') });
     } else {
       setSearchParams({});
     }
-  }, [eventTypeStrings, selectedEventTypes, setSearchParams]);
+  }, [eventTypes, selectedEventTypes, setSearchParams]);
 
   const updateEventFilters = (event: React.ChangeEvent<HTMLInputElement>) => {
 


### PR DESCRIPTION
[Issue resolved](https://github.com/admiralbolt/sms/issues/15) 

_demo video_

https://github.com/admiralbolt/sms/assets/27936344/faf7168e-5697-4622-8876-3af2837579e5


I still don't have my local fully-fully set up, but I think this works. 

This will allow end users - 
- solo individual event filters with one click
- share event-type-specific pages and have those event types persisted when someone opens the link 
